### PR TITLE
Updates formatting of README.rst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,0 +1,34 @@
+Building a Python ZIP Application
+---------------------------------
+
+To create a self-contained package including dependencies and binaries for you
+system, install shiv_.
+
+Download the source tarball from the Releases_ page, extract its contents,
+change into its root directory and run:
+
+.. code-block:: console
+
+    $ shiv -o quick-csr-<OS identifier>.pyz -c quick-csr .
+
+Installation as Python package
+------------------------------
+
+Beside obtaining ``quick-csr`` as ZIP Application, it can be installed the
+'classic' way.
+This is not recommended for users that are unexperienced with Python packaging
+and don't want to poke into its historical legacy.
+There's currently no package published on the Python Package Index, therefore
+you have to obtain the source code, change into its root directory and run:
+
+.. code-block:: console
+
+    $ pip install --user .
+
+Finally, to install a hackable instance of the software (assuming you created
+a virtual environment):
+
+.. code-block:: console
+
+    $ pip install --user --editable .
+

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -32,3 +32,5 @@ a virtual environment):
 
     $ pip install --user --editable .
 
+.. _releases: https://github.com/telota/quick-csr/releases
+.. _shiv: https://github.com/linkedin/shiv

--- a/README.rst
+++ b/README.rst
@@ -133,12 +133,9 @@ Now, with another profile for another OU (``laboratory``):
 
     quick-csr -c :laboratory living-concrete.cubs.org.il
 
-
+.. _INSTALL.rst: /INSTALL.rst
 .. _doskey: https://docs.microsoft.com/en-us/windows/console/console-aliases
 .. _CSR: https://en.wikipedia.org/wiki/Certificate_Signing_Request
 .. _issue: https://github.com/telota/quick-csr/issues
 .. _pipsi: https://pypi.python.org/pypi/pipsi
 .. _`PKCS #10`: https://tools.ietf.org/html/rfc2986
-.. _releases: https://github.com/telota/quick-csr/releases
-.. _shiv: https://github.com/linkedin/shiv
-.. _INSTALL.rst: /INSTALL.rst

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ quick-csr
 
 A command-line tool to quickly generate *Certificate Signing Requests* (CSR_),
 targeted to DAUs and busy people. The major desktop operating systems are
-supported. 
+supported.
 
 Configuration
 -------------
@@ -31,9 +31,9 @@ Deviant values for other usage contexts can be declared in further sections:
     [laboratory]
 
     organizationalUnitName = laboratory
-    
+
 Required options
-----------------
+~~~~~~~~~~~~~~~~
 
 These options must be present at least in the ``defaults`` section:
 
@@ -43,9 +43,8 @@ These options must be present at least in the ``defaults`` section:
 - ``stateOrProvinceName``
 - ``countryName``
 
-
 Additional options
-------------------
+~~~~~~~~~~~~~~~~~~
 
 - ``key_size``
    - length of the generated key in bits
@@ -54,49 +53,66 @@ Additional options
    - the resulting files are written there
    - defaults to the current working directory
 
+Use quick-csr as Python ZIP Application
+---------------------------------------
 
-.. _CSR: https://en.wikipedia.org/wiki/Certificate_Signing_Request
-.. _pipsi: https://pypi.python.org/pypi/pipsi
-.. _`PKCS #10`: https://tools.ietf.org/html/rfc2986
+With Python 3.5+ installed, ``quick-csr`` can be run on any system by executing
+an appropriate Python ZIP Application that includes all its dependencies and
+system specific binaries.
+See the Releases_ page to find ready-to-launch zip applications. If your OS is
+not (yet) supported, please head over to the next section or open an issue_ to
+request one.
 
-
-Use quick-csr as ZIP Application
---------------------------------
-With Python 3.5+ installed, quick-csr can be run on any system by executing a appropriate Python ZIP Application that includes all its dependencies and system specific binaries.
-See `releases <https://github.com/telota/quick-csr/releases>`_ to find ready-to-launch zip applications. If your OS is not (yet) supported, please head over to the next section.
-
-Usage is as described below but with your *filename* instead of *quick-csr*:
-
-.. code-block:: console
-
-    $ CSR-win7.pyz www.cubs.org.il
-Note that you have to be in the correct directory in the above case.
-Therefore is suggested to setup an `alias <https://docs.microsoft.com/en-us/windows/console/console-aliases>`_
-for a day-to-day usage:
+Usage is as described below but with the system specific *filename* instead of
+``quick-csr``:
 
 .. code-block:: console
 
-    $ doskey CSR=C:\Users\Me\Projekte\quick-csr\quick-csr-master\CSR-win7.pyz $*
-Regardless of your current working directory you can now run: 
+    $ quick-csr-win10.pyz www.cubs.org.il
+
+Note that the current working directory has to be in the directory in this
+case.
+
+Therefore it is suggested to setup an alias for a day-to-day usage.
+
+On POSIX compliant systems in an appropriate file, e.g. ``~/.bash_aliases``:
 
 .. code-block:: console
 
-    $ CSR www.cubs.org.il
+    alias quick-csr='~/…/quick-csr-linux-amd64.pyz'
 
+On windows, use the doskey_ command to setup an alias:
 
-Building a Python ZIP Application 
+.. code-block:: console
+
+    $ doskey quick-csr=C:\\Users\\Me\\quick-csr-win10.pyz $*
+
+Regardless of your current working directory you can now run:
+
+.. code-block:: console
+
+    $ quick-csr www.cubs.org.il
+
+Building a Python ZIP Application
 ---------------------------------
 
-To create a self-contained package including dependencies and binaries for you system, install `shiv <https://github.com/linkedin/shiv>`_. 
+To create a self-contained package including dependencies and binaries for you
+system, install shiv_.
 
-Download this repository, change into its root directory and run:
+Download the source tarball from the Releases_ page, extract its contents,
+change into its root directory and run:
 
 .. code-block:: console
 
-    $ shiv -o CSR-YOUR_OS.pyz -c quick-csr .
-Installation
-------------
+    $ shiv -o quick-csr-<OS identifier>.pyz -c quick-csr .
 
+Installation as Python package
+------------------------------
+
+Beside obtaining ``quick-csr`` as ZIP Application, it can be installed the
+'classic' way.
+This is not recommended for users that are unexperienced with Python packaging
+and don't want to poke into its historical legacy.
 There's currently no package published on the Python Package Index, therefore
 you have to obtain the source code, change into its root directory and run:
 
@@ -104,29 +120,12 @@ you have to obtain the source code, change into its root directory and run:
 
     $ pip install --user .
 
-To avoid conflicts within a system's ``site-package``'s namespace, it is
-however recommended to install any end-user-software in a separate virtual
-environment with pipsi_:
-
-.. code-block:: console
-
-    $ pipsi install .
-
-Alternatively, good experiences had been made by using pyenv-virtualenv to set up a Python 3.5.2 environment in the local quick-csr-folder. Then you can skip possible pipsi problems.
-
- .. code-block:: console
-
-    $ pyenv local quickcsr
-
 Finally, to install a hackable instance of the software (assuming you created
 a virtual environment):
 
 .. code-block:: console
 
-    $ pip install -e .
-
-
-
+    $ pip install --user --editable .
 
 
 What it does
@@ -142,9 +141,6 @@ certificate chain, e.g. on a web server.
 
     The keys are not secured with a password, so keep them in a safe location!
     Or add a password with ``openssl``.
-
-
-
 
 
 Usage
@@ -172,3 +168,10 @@ Now, with another profile for another OU (``laboratory``):
     quick-csr -c :laboratory living-concrete.cubs.org.il
 
 
+.. _doskey: https://docs.microsoft.com/en-us/windows/console/console-aliases
+.. _CSR: https://en.wikipedia.org/wiki/Certificate_Signing_Request
+.. _issue: https://github.com/telota/quick-csr/issues
+.. _pipsi: https://pypi.python.org/pypi/pipsi
+.. _`PKCS #10`: https://tools.ietf.org/html/rfc2986
+.. _releases: https://github.com/telota/quick-csr/releases
+.. _shiv: https://github.com/linkedin/shiv

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,8 @@ Now, with another profile for another OU (``laboratory``):
 .. code-block:: console
 
     quick-csr -c :laboratory living-concrete.cubs.org.il
-
+    
+.. _releases: https://github.com/telota/quick-csr/releases
 .. _INSTALL.rst: /INSTALL.rst
 .. _doskey: https://docs.microsoft.com/en-us/windows/console/console-aliases
 .. _CSR: https://en.wikipedia.org/wiki/Certificate_Signing_Request

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ With Python 3.5+ installed, ``quick-csr`` can be run on any system by executing
 an appropriate Python ZIP Application that includes all its dependencies and
 system specific binaries.
 See the Releases_ page to find ready-to-launch zip applications. If your OS is
-not (yet) supported, please head over to the next section or open an issue_ to
+not (yet) supported, please head over to INSTALL.rst_ or open an issue_ to
 request one.
 
 Usage is as described below but with the system specific *filename* instead of
@@ -92,40 +92,6 @@ Regardless of your current working directory you can now run:
 .. code-block:: console
 
     $ quick-csr www.cubs.org.il
-
-Building a Python ZIP Application
----------------------------------
-
-To create a self-contained package including dependencies and binaries for you
-system, install shiv_.
-
-Download the source tarball from the Releases_ page, extract its contents,
-change into its root directory and run:
-
-.. code-block:: console
-
-    $ shiv -o quick-csr-<OS identifier>.pyz -c quick-csr .
-
-Installation as Python package
-------------------------------
-
-Beside obtaining ``quick-csr`` as ZIP Application, it can be installed the
-'classic' way.
-This is not recommended for users that are unexperienced with Python packaging
-and don't want to poke into its historical legacy.
-There's currently no package published on the Python Package Index, therefore
-you have to obtain the source code, change into its root directory and run:
-
-.. code-block:: console
-
-    $ pip install --user .
-
-Finally, to install a hackable instance of the software (assuming you created
-a virtual environment):
-
-.. code-block:: console
-
-    $ pip install --user --editable .
 
 
 What it does
@@ -175,3 +141,4 @@ Now, with another profile for another OU (``laboratory``):
 .. _`PKCS #10`: https://tools.ietf.org/html/rfc2986
 .. _releases: https://github.com/telota/quick-csr/releases
 .. _shiv: https://github.com/linkedin/shiv
+.. _INSTALL.rst: /INSTALL.rst


### PR DESCRIPTION
this is mainly about formatting.

but let me raise an issue here. i understand why you moved the configuration section up and it makes sense. but now the usage part is fragmented and rather confusing. what about splitting the obtaining/building/installation stuff out to an `INSTALL.rst`?